### PR TITLE
Fix CRI-O install paths

### DIFF
--- a/cri-o/.SRCINFO
+++ b/cri-o/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = cri-o
 	pkgdesc = Open Container Initiative-based implementation of Kubernetes Container Runtime Interface
-	pkgver = 1.8.0
+	pkgver = 1.8.1
 	pkgrel = 1
 	url = https://github.com/kubernetes-incubator/cri-o
 	arch = i686

--- a/cri-o/PKGBUILD
+++ b/cri-o/PKGBUILD
@@ -8,6 +8,7 @@ arch=(i686 x86_64)
 url='https://github.com/kubernetes-incubator/cri-o'
 license=(Apache)
 makedepends=(go go-md2man ostree)
+backup=('etc/crio/crio.conf')
 source=("git+https://github.com/kubernetes-incubator/cri-o")
 sha256sums=('SKIP')
 
@@ -30,6 +31,21 @@ build() {
 
 package() {
 	cd "${srcdir}/go/src/github.com/kubernetes-incubator/cri-o"
+	
+	install -Dm755 bin/crio $pkgdir/usr/bin/crio
+	install -Dm755 bin/crioctl $pkgdir/usr/bin/crioctl
 
-	GOPATH="${srcdir}/go" make PREFIX="${pkgdir}" install
+	install -Dm755 bin/conmon $pkgdir/usr/libexec/crio/conmon
+	install -Dm755 bin/pause $pkgdir/usr/libexec/crio/pause
+
+	# install configs
+	install -dm755 $pkgdir/etc/crio/
+	install -Dm644 crio.conf $pkgdir/etc/crio/crio.conf
+	install -Dm644 seccomp.json $pkgdir/etc/crio/seccomp.json
+
+	# install manpages
+	install -d $pkgdir/usr/share/man/man5/
+	install -d $pkgdir/usr/share/man/man8/
+	install -pm644 docs/crio.conf.5 $pkgdir/usr/share/man/man5
+	install -pm644 docs/crio.8 $pkgdir/usr/share/man/man8
 }


### PR DESCRIPTION
Fixes:
```
error: failed to commit transaction (conflicting files)
cri-o: /bin exists in filesystem
Errors occurred, no packages were upgraded. 
```

Also updates CRI-O to 1.8.1